### PR TITLE
Randomize pod init position

### DIFF
--- a/src/Application/Server.cpp
+++ b/src/Application/Server.cpp
@@ -86,8 +86,11 @@ void Server::run()
 		LOG_SCOPE_FUNCTION(2);
         // Receive incoming user commands
         LOG_F(2, "Handling incoming commands");
+        LOG_F(4, "Message Consumer Dispatch");
         m_theMessageConsumer.Dispatch();
+        LOG_F(4, "Command Consumer Consume");
         m_theCommandConsumer.Consume();
+        LOG_F(4, "Command Queue Execute");
         m_theCommandQueue.Execute();
         
         // Run simulation step
@@ -103,9 +106,12 @@ void Server::run()
         // if any client needs a world update take world snapshot
         // Update clients if required
         LOG_F(2, "Telling the clients what's going on");
+        LOG_F(4, "Event Dispatcher Dispatch");
         m_theEventDispatcher.Dispatch();
+        LOG_F(4, "Message Dispatcher Dispatch");
         m_theMessageDispatcher.Dispatch();
         
+        LOG_F(4, "Game Sleep");
         std::this_thread::sleep_for(std::chrono::milliseconds(Configuration::Instance().SleepCycle));
     }
 }

--- a/src/Commands/CommandQueue.cpp
+++ b/src/Commands/CommandQueue.cpp
@@ -88,23 +88,24 @@ void CommandQueue::HandleCommandConsumedEvent(const void* pSender, Poco::Tuple<p
     
     ACommand* pCommand = NULL;
 
-    LOG_SCOPE_F(1, "command event received");
-    LOG_SCOPE_F(1, "received command buffer type: %i", pCommandBuffer->type());
+    LOG_SCOPE_F(4, "command event received");
+    LOG_SCOPE_F(8, "received command buffer type: %i", pCommandBuffer->type());
 
     if (redhatgamedev::srt::CommandBuffer_CommandBufferType_SECURITY == pCommandBuffer->type())
     {
         const SecurityCommandBuffer& aSecurityCommandBuffer = pCommandBuffer->securitycommandbuffer();
-        LOG_SCOPE_F(1, "security command");
-        LOG_SCOPE_F(1, "received security command type: %i", aSecurityCommandBuffer.type());
+        LOG_SCOPE_F(4, "security command");
+        LOG_SCOPE_F(8, "received security command type: %i", aSecurityCommandBuffer.type());
 
         if (redhatgamedev::srt::SecurityCommandBuffer_SecurityCommandBufferType_JOIN == aSecurityCommandBuffer.type())
         {
-            LOG_SCOPE_F(1, "join message received");
+            LOG_SCOPE_F(4, "join message received");
             JoinSecurityCommand::_SecurityDependencies theJoinSecurityCommandDependencies(pCommandBuffer, pBytesMessage);
             pCommand = m_aJoinSecurityCommandFactory.Create(theJoinSecurityCommandDependencies);
         }
         else if (redhatgamedev::srt::SecurityCommandBuffer_SecurityCommandBufferType_LEAVE == aSecurityCommandBuffer.type())
         {
+            LOG_SCOPE_F(4, "leave message received");
             LeaveSecurityCommand::_SecurityDependencies theLeaveSecurityCommandDependencies(pCommandBuffer, pBytesMessage);
             pCommand = m_aLeaveSecurityCommandFactory.Create(theLeaveSecurityCommandDependencies);
         }

--- a/src/Commands/JoinSecurityCommand.cpp
+++ b/src/Commands/JoinSecurityCommand.cpp
@@ -18,7 +18,6 @@
 #include "../Proto/SecurityCommandBuffer.pb.h"
 #include <proton/message.hpp>
 #include <assert.h>
-#include <iostream>
 #include "../Logging/loguru.hpp"
 
 

--- a/src/Commands/LeaveSecurityCommand.cpp
+++ b/src/Commands/LeaveSecurityCommand.cpp
@@ -13,9 +13,12 @@
 //   limitations under the License.
 
 #include "LeaveSecurityCommand.h"
+#include "../Application/Configuration.h"
 #include "../Proto/CommandBuffer.pb.h"
 #include "../Proto/SecurityCommandBuffer.pb.h"
+#include <proton/message.hpp>
 #include <assert.h>
+#include "../Logging/loguru.hpp"
 
 
 // Constructor
@@ -36,11 +39,15 @@ void LeaveSecurityCommand::Execute()
 {
     using namespace redhatgamedev::srt;
     
+    assert(m_pBytesMessage);
     assert(m_pCommandBuffer);
     
+    std::string     strUUID = "";
     const SecurityCommandBuffer& aSecurityCommandBuffer = m_pCommandBuffer->securitycommandbuffer();
-    const LeaveSecurityCommandBuffer& aLeaveSecurityCommandBuffer = aSecurityCommandBuffer.leavesecuritycommandbuffer();
-    const std::string& strUUID = aLeaveSecurityCommandBuffer.uuid();
+    LOG_SCOPE_F(INFO, "provided player identity: %s", aSecurityCommandBuffer.uuid().c_str());
+
+    //const LeaveSecurityCommandBuffer& aLeaveSecurityCommandBuffer = aSecurityCommandBuffer.leavesecuritycommandbuffer();
+    strUUID = aSecurityCommandBuffer.uuid();
     
     ExecutedEvent(this, strUUID);
 }

--- a/src/Events/EventDispatcher.cpp
+++ b/src/Events/EventDispatcher.cpp
@@ -108,7 +108,7 @@ EventDispatcher::~EventDispatcher()
 // Helper(s)
 void EventDispatcher::Enqueue(Message* pMessage)
 {
-    LOG_SCOPE_FUNCTION(8);
+    LOG_SCOPE_FUNCTION(4);
     m_anEventQueueMutex.lock();
     m_anEventQueue.push(pMessage);
     m_anEventQueueMutex.unlock();
@@ -116,7 +116,7 @@ void EventDispatcher::Enqueue(Message* pMessage)
 
 Message* EventDispatcher::Dequeue()
 {
-    LOG_SCOPE_FUNCTION(8);
+    LOG_SCOPE_FUNCTION(4);
     Message* pMessage = NULL;
 
     m_anEventQueueMutex.lock();
@@ -129,7 +129,7 @@ Message* EventDispatcher::Dequeue()
 
 GameEventBuffer* EventDispatcher::CreateGameEvent(EntityGameEventBuffer_EntityGameEventBufferType eEntityGameEvent_EntityGameEventBufferType, AEntity* pEntity)
 {
-    LOG_SCOPE_FUNCTION(8);
+    LOG_SCOPE_FUNCTION(4);
     LOG_F(8, "Entity Game Event");
     EntityGameEvent_Dependencies anEntityGameEvent_Dependencies(eEntityGameEvent_EntityGameEventBufferType, pEntity);
     GameEventBuffer* pGameEvent = m_anEntityGameEventFactory.Create(anEntityGameEvent_Dependencies);
@@ -139,7 +139,7 @@ GameEventBuffer* EventDispatcher::CreateGameEvent(EntityGameEventBuffer_EntityGa
 
 GameEventBuffer* EventDispatcher::CreateGameEvent(SecurityGameEventBuffer_SecurityGameEventBufferType eSecurityGameEvent_SecurityGameEventBufferType, const std::string& strUUID)
 {
-    LOG_SCOPE_FUNCTION(8);
+    LOG_SCOPE_FUNCTION(4);
     LOG_F(8, "Security Game Event");
     SecurityGameEvent_Dependencies aSecurityGameEvent_Dependencies(eSecurityGameEvent_SecurityGameEventBufferType, strUUID);
     GameEventBuffer* pGameEvent = m_aSecurityGameEventFactory.Create(aSecurityGameEvent_Dependencies);
@@ -150,7 +150,7 @@ GameEventBuffer* EventDispatcher::CreateGameEvent(SecurityGameEventBuffer_Securi
 // Dispatches all the events it has received to it's listeners
 void EventDispatcher::Dispatch()
 {
-    LOG_SCOPE_FUNCTION(8);
+    LOG_SCOPE_FUNCTION(4);
     Message* pMessage = NULL;
     m_anEventQueueMutex.lock();
     while (!m_anEventQueue.empty())
@@ -165,40 +165,40 @@ void EventDispatcher::Dispatch()
 // Entity event response
 void EventDispatcher::HandlePodCreatedEvent(const void* pSender, Pod*& pPod)
 {
-    LOG_SCOPE_FUNCTION(8);
+    LOG_SCOPE_FUNCTION(4);
     GameEventBuffer* pGameEvent = CreateGameEvent(EntityGameEventBuffer_EntityGameEventBufferType_CREATE, static_cast<AEntity*>(pPod));
     Enqueue(pGameEvent);
 }
 
 void EventDispatcher::HandlePodUpdatedEvent(const void* pSender, Pod*& pPod)
 {
-    LOG_SCOPE_FUNCTION(8);
+    LOG_SCOPE_FUNCTION(4);
     GameEventBuffer* pGameEvent = CreateGameEvent(EntityGameEventBuffer_EntityGameEventBufferType_UPDATE, static_cast<AEntity*>(pPod));
     Enqueue(pGameEvent);}
 
 void EventDispatcher::HandlePodDestroyedEvent(const void* pSender, Pod*& pPod)
 {
-    LOG_SCOPE_FUNCTION(8);
+    LOG_SCOPE_FUNCTION(4);
     GameEventBuffer* pGameEvent = CreateGameEvent(EntityGameEventBuffer_EntityGameEventBufferType_DESTROY, static_cast<AEntity*>(pPod));
     Enqueue(pGameEvent);}
 
 void EventDispatcher::HandleBulletCreatedEvent(const void* pSender, Bullet*& pBullet)
 {
-    LOG_SCOPE_FUNCTION(8);
+    LOG_SCOPE_FUNCTION(4);
     GameEventBuffer* pGameEvent = CreateGameEvent(EntityGameEventBuffer_EntityGameEventBufferType_CREATE, static_cast<AEntity*>(pBullet));
     Enqueue(pGameEvent);
 }
 
 void EventDispatcher::HandleBulletUpdatedEvent(const void* pSender, Bullet*& pBullet)
 {
-    LOG_SCOPE_FUNCTION(8);
+    LOG_SCOPE_FUNCTION(4);
     GameEventBuffer* pGameEvent = CreateGameEvent(EntityGameEventBuffer_EntityGameEventBufferType_UPDATE, static_cast<AEntity*>(pBullet));
     Enqueue(pGameEvent);
 }
 
 void EventDispatcher::HandleBulletDestroyedEvent(const void* pSender, Bullet*& pBullet)
 {
-    LOG_SCOPE_FUNCTION(8);
+    LOG_SCOPE_FUNCTION(4);
     GameEventBuffer* pGameEvent = CreateGameEvent(EntityGameEventBuffer_EntityGameEventBufferType_DESTROY, static_cast<AEntity*>(pBullet));
     Enqueue(pGameEvent);
 }
@@ -206,7 +206,7 @@ void EventDispatcher::HandleBulletDestroyedEvent(const void* pSender, Bullet*& p
 // Event Consumer event response
 void EventDispatcher::HandleJoinSecurityCommandFactoryCreatedEvent(const void* pSender, JoinSecurityCommand*& pJoinSecurityCommand)
 {
-    LOG_SCOPE_FUNCTION(8);
+    LOG_SCOPE_FUNCTION(4);
     assert(pJoinSecurityCommand);
     
     pJoinSecurityCommand->ExecutedEvent += Poco::Delegate<EventDispatcher, const std::string&>(this, &EventDispatcher::HandleJoinSecurityCommandExecutedEvent);
@@ -214,7 +214,7 @@ void EventDispatcher::HandleJoinSecurityCommandFactoryCreatedEvent(const void* p
 
 void EventDispatcher::HandleJoinSecurityCommandFactoryDestroyedEvent(const void* pSender, JoinSecurityCommand*& pJoinSecurityCommand)
 {
-    LOG_SCOPE_FUNCTION(8);
+    LOG_SCOPE_FUNCTION(4);
     assert(pJoinSecurityCommand);
     
     pJoinSecurityCommand->ExecutedEvent -= Poco::Delegate<EventDispatcher, const std::string&>(this, &EventDispatcher::HandleJoinSecurityCommandExecutedEvent);
@@ -222,7 +222,7 @@ void EventDispatcher::HandleJoinSecurityCommandFactoryDestroyedEvent(const void*
 
 void EventDispatcher::HandleLeaveSecurityCommandFactoryCreatedEvent(const void* pSender, LeaveSecurityCommand*& pLeaveSecurityCommand)
 {
-    LOG_SCOPE_FUNCTION(8);
+    LOG_SCOPE_FUNCTION(4);
     assert(pLeaveSecurityCommand);
     
     pLeaveSecurityCommand->ExecutedEvent += Poco::Delegate<EventDispatcher, const std::string&>(this, &EventDispatcher::HandleLeaveSecurityCommandExecutedEvent);
@@ -230,7 +230,7 @@ void EventDispatcher::HandleLeaveSecurityCommandFactoryCreatedEvent(const void* 
 
 void EventDispatcher::HandleLeaveSecurityCommandFactoryDestroyedEvent(const void* pSender, LeaveSecurityCommand*& pLeaveSecurityCommand)
 {
-    LOG_SCOPE_FUNCTION(8);
+    LOG_SCOPE_FUNCTION(4);
     assert(pLeaveSecurityCommand);
     
     pLeaveSecurityCommand->ExecutedEvent -= Poco::Delegate<EventDispatcher, const std::string&>(this, &EventDispatcher::HandleLeaveSecurityCommandExecutedEvent);
@@ -238,14 +238,16 @@ void EventDispatcher::HandleLeaveSecurityCommandFactoryDestroyedEvent(const void
 
 void EventDispatcher::HandleJoinSecurityCommandExecutedEvent(const void* pSender, const std::string& strUUID)
 {
-    LOG_SCOPE_FUNCTION(8);
+    LOG_SCOPE_FUNCTION(4);
+    LOG_SCOPE_F(4, "UUID: %s", strUUID.c_str());
     GameEventBuffer* pGameEvent = CreateGameEvent(SecurityGameEventBuffer_SecurityGameEventBufferType_JOIN, strUUID);
     Enqueue(pGameEvent);
 }
 
 void EventDispatcher::HandleLeaveSecurityCommandExecutedEvent(const void* pSender, const std::string& strUUID)
 {
-    LOG_SCOPE_FUNCTION(8);
+    LOG_SCOPE_FUNCTION(4);
+    LOG_SCOPE_F(4, "UUID: %s", strUUID.c_str());
     GameEventBuffer* pGameEvent = CreateGameEvent(SecurityGameEventBuffer_SecurityGameEventBufferType_LEAVE, strUUID);
     Enqueue(pGameEvent);
 }

--- a/src/Game/AEntity.cpp
+++ b/src/Game/AEntity.cpp
@@ -93,6 +93,7 @@ void AEntity::ClassTeardown()
 
 void AEntity::AddPod(const std::string& strUUID)
 {
+    LOG_SCOPE_FUNCTION(4);
     assert(strUUID.length() > 0);
     
     B2DPodFactory& aB2DPodFactory = B2DPodFactory::Instance();
@@ -112,6 +113,7 @@ void AEntity::AddPod(const std::string& strUUID)
 
 void AEntity::RemovePod(const std::string& strUUID)
 {
+    LOG_SCOPE_FUNCTION(4);
     assert(strUUID.length() > 0);
     
     PodFactory& aPodFactory = PodFactory::Instance();
@@ -133,8 +135,8 @@ void AEntity::RemovePod(const std::string& strUUID)
 
 void AEntity::Update()
 {
-    LOG_SCOPE_FUNCTION(3);
-    LOG_SCOPE_F(3, "Doing the AEntity update");
+    LOG_SCOPE_FUNCTION(4);
+    LOG_SCOPE_F(4, "Doing the AEntity update");
     s_listPodsSwap = s_listPods;
     Pod*     pPod = NULL;
     
@@ -151,6 +153,7 @@ void AEntity::Update()
 // Security::ICallbacks implementation
 void AEntity::OnSecurityRequestJoin(const void* pSender, const std::string& strUUID)
 {
+    LOG_SCOPE_FUNCTION(4);
     assert(!strUUID.empty());
     
     AddPod(strUUID);
@@ -158,6 +161,7 @@ void AEntity::OnSecurityRequestJoin(const void* pSender, const std::string& strU
 
 void AEntity::OnSecurityRequestLeave(const void* pSender, const std::string& strUUID)
 {
+    LOG_SCOPE_FUNCTION(4);
     assert(!strUUID.empty());
     
     RemovePod(strUUID);
@@ -165,6 +169,7 @@ void AEntity::OnSecurityRequestLeave(const void* pSender, const std::string& str
 
 void AEntity::HandleJoinSecurityCommandFactoryCreated(const void* pSender, JoinSecurityCommand*& pJoinSecurityCommand)
 {
+    LOG_SCOPE_FUNCTION(4);
     assert(pJoinSecurityCommand);
     
     pJoinSecurityCommand->ExecutedEvent += Poco::FunctionDelegate<const std::string&>(&AEntity::OnSecurityRequestJoin);
@@ -172,6 +177,7 @@ void AEntity::HandleJoinSecurityCommandFactoryCreated(const void* pSender, JoinS
 
 void AEntity::HandleJoinSecurityCommandFactoryDestroyed(const void* pSender, JoinSecurityCommand*& pJoinSecurityCommand)
 {
+    LOG_SCOPE_FUNCTION(4);
     assert(pJoinSecurityCommand);
     
     pJoinSecurityCommand->ExecutedEvent -= Poco::FunctionDelegate<const std::string&>(&AEntity::OnSecurityRequestJoin);
@@ -179,6 +185,7 @@ void AEntity::HandleJoinSecurityCommandFactoryDestroyed(const void* pSender, Joi
 
 void AEntity::HandleLeaveSecurityCommandFactoryCreated(const void* pSender, LeaveSecurityCommand*& pLeaveSecurityCommand)
 {
+    LOG_SCOPE_FUNCTION(4);
     assert(pLeaveSecurityCommand);
     
     pLeaveSecurityCommand->ExecutedEvent += Poco::FunctionDelegate<const std::string&>(&AEntity::OnSecurityRequestLeave);
@@ -186,6 +193,7 @@ void AEntity::HandleLeaveSecurityCommandFactoryCreated(const void* pSender, Leav
 
 void AEntity::HandleLeaveSecurityCommandFactoryDestroyed(const void* pSender, LeaveSecurityCommand*& pLeaveSecurityCommand)
 {
+    LOG_SCOPE_FUNCTION(4);
     assert(pLeaveSecurityCommand);
     
     pLeaveSecurityCommand->ExecutedEvent -= Poco::FunctionDelegate<const std::string&>(&AEntity::OnSecurityRequestLeave);

--- a/src/Game/AEntity.cpp
+++ b/src/Game/AEntity.cpp
@@ -26,6 +26,7 @@
 #include <box2d/box2d.h>
 #include <Poco/FunctionDelegate.h>
 #include <assert.h>
+#include <random>
 #include "../Logging/loguru.hpp"
 
 std::queue<AEntity*>            AEntity::s_EntityQueue;
@@ -91,6 +92,13 @@ void AEntity::ClassTeardown()
     theLeaveSecurityCommandFactory.CreatedEvent -= Poco::FunctionDelegate<LeaveSecurityCommand*&>(&AEntity::HandleLeaveSecurityCommandFactoryCreated);
 }
 
+float get_random()
+{
+    static std::default_random_engine e;
+    static std::uniform_real_distribution<> dis(-1, 1); // rage 0 - 1
+    return dis(e);
+}
+
 void AEntity::AddPod(const std::string& strUUID)
 {
     LOG_SCOPE_FUNCTION(4);
@@ -98,10 +106,14 @@ void AEntity::AddPod(const std::string& strUUID)
     
     B2DPodFactory& aB2DPodFactory = B2DPodFactory::Instance();
     PodFactory& aPodFactory = PodFactory::Instance();
-    
+
+    // initialize a random X and Y position
+    // TODO: make the scaling constant a config option
+    // TODO: we need to figure out how to reasonably distribute players, as opposed to
+    //       just randomly plopping them on the board
     b2Vec2 b2v2Position;
-    b2v2Position.x = 0.0f;
-    b2v2Position.y = 0.0f;
+    b2v2Position.x = 600.0f * get_random();
+    b2v2Position.y = 600.0f * get_random();
     const b2Vec2& b2v2PositionRef = b2v2Position;
     B2DPod::_Dependencies aB2DPodDependencies(b2v2PositionRef);
     B2DPod* pB2DPod = aB2DPodFactory.Create(aB2DPodDependencies);

--- a/src/Game/Pod.cpp
+++ b/src/Game/Pod.cpp
@@ -50,7 +50,7 @@ Pod::Pod(_Dependencies& theDependencies) :
     m_i16GroupCount = s_i16GroupCount;
     
     m_pB2DEntity->SetParentEntity(this);
-    LOG_F(INFO, "Setting pod GroupIndex to %i", m_i16GroupCount);
+    LOG_F(4, "Setting pod GroupIndex to %i", m_i16GroupCount);
     m_pB2DEntity->SetGroupIndex(m_i16GroupCount);
     
     auto&      theDualStickRawInputCommandFactory = FactoryT<DualStickRawInputCommand, RawInputCommand::_RawInputDependencies>::Instance();
@@ -85,7 +85,8 @@ Pod::~Pod()
 // Method(s)
 void Pod::Update()
 {
-    LOG_SCOPE_F(2, "Updating the pod: %s", UUID.c_str());
+    LOG_SCOPE_FUNCTION(4);
+    LOG_SCOPE_F(4, "Updating the pod: %s", UUID.c_str());
     assert(m_pB2DEntity);
     assert(m_pBulletTimer);
 
@@ -93,26 +94,26 @@ void Pod::Update()
     BulletFactory& aBulletFactory = BulletFactory::Instance();
 
     m_b2v2MoveQueueMutex.lock();
-    LOG_F(3, "Grabbing movement commands off the queue");
+    LOG_F(4, "Grabbing movement commands off the queue");
     std::vector<b2Vec2> vecb2v2Move = {m_b2v2MoveQueue.begin(), m_b2v2MoveQueue.end()};
     m_b2v2MoveQueue.clear();
     m_b2v2MoveQueueMutex.unlock();
     
     for (int i = 0; i < vecb2v2Move.size(); ++i)
     {
-        LOG_SCOPE_F(3, "Moving the pod with a queued command vector");
+        LOG_SCOPE_F(4, "Moving the pod with a queued command vector");
         m_pB2DEntity->Move(vecb2v2Move[i].x, vecb2v2Move[i].y);
     }
     
     m_b2v2ShootQueueMutex.lock();
-    LOG_F(3, "Grabbing shooting commands off the queue");
+    LOG_F(4, "Grabbing shooting commands off the queue");
     std::vector<b2Vec2> vecb2v2Shoot = { m_b2v2ShootQueue.begin(), m_b2v2ShootQueue.end()};
     m_b2v2ShootQueue.clear();
     m_b2v2ShootQueueMutex.unlock();
 
     for (int i = 0; i < vecb2v2Shoot.size(); ++i)
     {
-        LOG_SCOPE_F(3, "Check if the bullet timer is expired");
+        LOG_SCOPE_F(4, "Check if the bullet timer is expired");
         if (m_pBulletTimer->Status() == Rock2D::Timer::EXPIRED)
         {
             m_pBulletTimer->Restart();
@@ -131,9 +132,9 @@ void Pod::Update()
         }
     }
     
-    LOG_F(3, "Update our Rock2D timer");
+    LOG_F(4, "Update our Rock2D timer");
     Rock2D::Timer::Update();
-    LOG_F(3, "Update our B2D Pod to apply forces");
+    LOG_F(4, "Update our B2D Pod to apply forces");
     m_pB2DEntity->Update();
 
     Pod* pPod = this;

--- a/src/Network/MessageDispatcher.cpp
+++ b/src/Network/MessageDispatcher.cpp
@@ -133,7 +133,7 @@ std::pair<const unsigned char*, unsigned long>* MessageDispatcher::MessageToPair
 void MessageDispatcher::Dispatch()
 {
     int x = 1;
-    LOG_SCOPE_FUNCTION(3);
+    LOG_SCOPE_FUNCTION(4);
     m_aMessageQueueMutex.lock();
     while (!m_aMessageQueue.empty())
     {
@@ -154,9 +154,9 @@ void MessageDispatcher::Dispatch()
                 msg.content_type("proton::BINARY");
                 msg.content_encoding("proton::BINARY");
 
-                LOG_F(7, "message #: %i", x);
-                LOG_F(7, "proton msg body type is %s", proton::type_name(msg.body().type()).c_str());
-                LOG_F(7, "proton msg content_type is %s", msg.content_type().c_str());
+                LOG_F(8, "message #: %i", x);
+                LOG_F(8, "proton msg body type is %s", proton::type_name(msg.body().type()).c_str());
+                LOG_F(8, "proton msg content_type is %s", msg.content_type().c_str());
                 LOG_F(8, "proton msg content_encoding is %s", msg.content_encoding().c_str());
                 LOG_F(7, "proton msg body is %s", proton::coerce<std::string>(msg.body()).c_str());
 


### PR DESCRIPTION
This is a total hackjob using random. There's no logic to it. It doesn't check where anyone already is. But it's a start.

In order to properly do this, we probably need to pass in the array of existing players we know about and then use some distribution function to place the next player.